### PR TITLE
Add support for alternative social links in ¿Quién viene? section

### DIFF
--- a/block_pages/index.yml
+++ b/block_pages/index.yml
@@ -245,6 +245,16 @@ blocks:
             url: 'https://www.linkedin.com/in/dgomezg'
           - icon: x-logo
             url: 'https://x.com/dgomezg'
+          - icon: butterfly
+            url: 'https://bsky.app/profile/dgomezg.bsky.social'
+          - icon: mastodon-logo
+            url: 'https://mastodon.social/@dgomezg'
+          - icon: github-logo
+            url: 'https://github.com/dgomezg'
+          - icon: instagram-logo
+            url: 'https://www.instagram.com/dgomezg.dev'
+          - icon: globe
+            url: 'https://dgomezg.dev/'
       - name: Gonzalo Ortiz
         id: gonzalo-ortiz
         company: StarTree
@@ -307,15 +317,6 @@ blocks:
           compartir experiencias e ideas en un entorno tan acogedor.
         image: /files/people/JorgeAguilera.jpg
         links: []
-      - name: Jose Ignacio Domínguez
-        id: joseignacio-dominguez
-        company: Clarity AI
-        bio: |-
-          **Staff Software Engineer**
-        image: /files/people/avatar.webp
-        links:
-          - icon: linkedin-logo
-            url: 'https://www.linkedin.com/in/joseignaciodominguez/'
       - name: Jorge Hidalgo
         id: jorge-hidalgo
         company: Accenture
@@ -331,6 +332,15 @@ blocks:
             url: 'https://www.linkedin.com/in/deors/'
           - icon: x-logo
             url: 'https://x.com/deors314'
+      - name: Jose Ignacio Domínguez
+        id: joseignacio-dominguez
+        company: Clarity AI
+        bio: |-
+          **Staff Software Engineer**
+        image: /files/people/avatar.webp
+        links:
+          - icon: linkedin-logo
+            url: 'https://www.linkedin.com/in/joseignaciodominguez/'
   - type: separator
     width: is-default
   - type: logos


### PR DESCRIPTION
## Summary
- Adds support for alternative social platforms beyond LinkedIn and X/Twitter
- Updates David Gómez profile with BlueSky, Mastodon, GitHub, Instagram and personal website links
- Sorts speakers alphabetically by name

## Supported social platforms
The following icons are now demonstrated/available for use:
- `butterfly` - BlueSky
- `mastodon-logo` - Mastodon  
- `github-logo` - GitHub
- `instagram-logo` - Instagram
- `linktree-logo` - Linktree
- `globe` - Personal website

## Example usage
```yaml
links:
  - icon: butterfly
    url: 'https://bsky.app/profile/username.bsky.social'
  - icon: mastodon-logo
    url: 'https://mastodon.social/@username'
  - icon: github-logo
    url: 'https://github.com/username'
  - icon: instagram-logo
    url: 'https://www.instagram.com/username'
  - icon: globe
    url: 'https://example.com'
```